### PR TITLE
Updated bridge and py.run

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@ from aqt.fields import FieldDialog
 from anki.hooks import wrap
 from anki.utils import splitFields, stripHTMLMedia
 from anki.utils import json
-import urllib2
+import urllib.request, urllib.error, urllib.parse
 
 noAutocompleteFields = [  ]
 
@@ -26,14 +26,14 @@ def mySetup(self, note, hide=True, focus=False):
                         text: currentField.innerHTML,
                     };
 
-                    py.run("autocomplete:" + JSON.stringify(r));
+                    pycmd("autocomplete:" + JSON.stringify(r));
                 }
             }, 1000);
         """)
 
-def myBridge(self, str, _old=None):
-    if str.startswith("autocomplete"):
-        (type, jsonText) = str.split(":", 1)
+def myBridge(self, cmd, _old=None):
+    if cmd.startswith("autocomplete"):
+        (type, jsonText) = cmd.split(":", 1)
         result = json.loads(jsonText)
         text = self.mungeHTML(result['text'])
 
@@ -52,7 +52,7 @@ def myBridge(self, str, _old=None):
         if field['name'] in noAutocompleteFields:
             field['no_autocomplete'] = True
 
-        if 'no_autocomplete' in field.keys() and field['no_autocomplete']:
+        if 'no_autocomplete' in list(field.keys()) and field['no_autocomplete']:
             return
 
         # find a value from the same model and field whose
@@ -87,13 +87,13 @@ def myBridge(self, str, _old=None):
         """
         % (escaped, escaped))
     else:
-        _old(self, str)
+        _old(self, cmd)
 
 # XXX must figure out how to add noAutocomplete checkbox to form
 def myLoadField(self, idx):
     fld = self.model['flds'][idx]
     f = self.form
-    if 'no_autocomplete' in fld.keys():
+    if 'no_autocomplete' in list(fld.keys()):
         f.noAutocomplete.setChecked(fld['no_autocomplete'])
 
 def mySaveField(self):
@@ -105,7 +105,7 @@ def mySaveField(self):
     f = self.form
     fld['no_autocomplete'] = f.noAutocomplete.isChecked()
 
-editor.Editor.bridge = wrap(editor.Editor.bridge, myBridge, 'around')
+editor.Editor.onBridgeCmd = wrap(editor.Editor.onBridgeCmd, myBridge, 'around')
 editor.Editor.setNote = wrap(editor.Editor.setNote, mySetup, 'after')
 
 #FieldDialog.loadField = wrap(FieldDialog.loadField, myLoadField, 'after')


### PR DESCRIPTION
The main changes were from updates to the webview, the bridge function was replaced with onBridgeCmd and the py.run for the javascript was replaced with pycmd. The 2to3 was run successfully as well and the autocomplete shows up as expected. Additionally, the new add-on format requires a folder with \_\_init\_\_.py instead of a named python file, the named file has been modified to reflect this.